### PR TITLE
Fix glob import in copy-html-files.js

### DIFF
--- a/.scripts/copy-html-files.js
+++ b/.scripts/copy-html-files.js
@@ -1,5 +1,5 @@
 const fs = require('fs-extra');
-const glob = require('glob');
+const glob = require('glob').glob;
 const path = require('path');
 
 // Define the source and destination directories


### PR DESCRIPTION
This pull request fixes the import of the glob module in the copy-html-files.js file. Previously, the import statement was incorrect, causing an error. This PR updates the import statement to use the correct syntax, resolving the issue.